### PR TITLE
admin get_image should fail silently if image is missing

### DIFF
--- a/blogit/admin.py
+++ b/blogit/admin.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils import formats
 
 from easy_thumbnails.files import get_thumbnailer
+from easy_thumbnails.exceptions import InvalidImageFormatError
 from parler.admin import TranslatableAdmin
 from cms.admin.placeholderadmin import (
     PlaceholderAdminMixin, FrontendEditableAdminMixin)
@@ -141,7 +142,7 @@ class PostAdmin(FrontendEditableAdminMixin, PlaceholderAdminMixin,
             thumbnailer = get_thumbnailer(obj.featured_image)
             thumb = thumbnailer.get_thumbnail(options)
             return '<img src="{}">'.format(thumb.url)
-        except (IOError, ValueError):
+        except (IOError, ValueError, InvalidImageFormatError):
             return None
     get_image.short_description = _('Image')
     get_image.allow_tags = True


### PR DESCRIPTION
In case of missing or corrupt image files (I just had a case of that), get_image should fail silently and not raise an exception that causes django's yellow stacktrace screen within admin.