### PR TITLE
Add CMS Plugins

### DIFF
--- a/blogit/cms_plugins.py
+++ b/blogit/cms_plugins.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
+from cms.models.pluginmodel import CMSPlugin
+
+from blogit.models import Post, Tag, Category, PostList
+from blogit.utils import paginate_queryset
+
+
+class PostListPlugin(CMSPluginBase):
+    model = PostList
+    module = "Blogit"
+    name = "Post List"
+    render_template = "blogit/plugins/post_list.html"
+
+    def render(self, context, instance, placeholder):
+        request = context['request']
+        qs = Post.objects.published(request)
+        filters = {}
+        if instance.filter_by_author:
+            filters['author'] = instance.filter_by_author
+        if instance.filter_by_category:
+            filters['category'] = instance.filter_by_category
+        if instance.filter_by_tags.count() > 0:
+            filters['tags'] = instance.filter_by_tags.all()
+        if filters:
+            qs = qs.filter(**filters)
+        print filters
+        paginator, page, queryset, is_paginated = paginate_queryset(
+            qs, request.GET.get('page', 1), instance.show_paginator,
+            instance.number_of_posts, instance.orphans)
+        context.update({
+            'paginator': paginator,
+            'page_obj': page,
+            'is_paginated': is_paginated and instance.show_paginator,
+            'object_list': queryset
+        })
+        return context
+
+    def get_render_template(self, context, instance, placeholder):
+        return instance.template_name or self.render_template
+
+
+class TagListPlugin(CMSPluginBase):
+    model = CMSPlugin
+    module = "Blogit"
+    name = "Tag List"
+    render_template = "blogit/plugins/tag_list.html"
+
+    def render(self, context, instance, placeholder):
+        context.update({'object_list': Tag.objects.filter(active=True)})
+        return context
+
+
+class CategoryListPlugin(CMSPluginBase):
+    model = CMSPlugin
+    module = "Blogit"
+    name = "Category List"
+    render_template = "blogit/plugins/category_list.html"
+
+    def render(self, context, instance, placeholder):
+        context.update({'object_list': Category.objects.filter(active=True)})
+        return context
+
+
+plugin_pool.register_plugin(PostListPlugin)
+plugin_pool.register_plugin(TagListPlugin)
+plugin_pool.register_plugin(CategoryListPlugin)

--- a/blogit/migrations/0002_postlist.py
+++ b/blogit/migrations/0002_postlist.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import mptt.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('blogit', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PostList',
+            fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('number_of_posts', models.IntegerField(default=10)),
+                ('show_paginator', models.BooleanField(default=True)),
+                ('orphans', models.IntegerField(default=0)),
+                ('template_name', models.CharField(help_text='Select a template or leave empty for default one.', max_length=200, blank=True)),
+                ('filter_by_author', models.ForeignKey(related_name='filtered_by_author', blank=True, to=settings.AUTH_USER_MODEL, help_text='Filter by author or leave blank for all authors.', null=True, verbose_name='Filter by author')),
+                ('filter_by_category', mptt.fields.TreeForeignKey(related_name='filtered_by_category', blank=True, to='blogit.Category', help_text='Filter by category or leave blank for all categories.', null=True, verbose_name='Category')),
+                ('filter_by_tags', models.ManyToManyField(related_name='filtered_by_tags', to='blogit.Tag', blank=True, help_text='Filter by tags (one or more) or leave blank for all tags.', null=True, verbose_name='Tags')),
+            ],
+            options={
+                'db_table': 'blogit_post_lists',
+            },
+            bases=('cms.cmsplugin',),
+        ),
+    ]

--- a/blogit/models.py
+++ b/blogit/models.py
@@ -16,6 +16,7 @@ except ImportError:
 from mptt.models import MPTTModel, TreeForeignKey
 from parler.models import TranslatableModel, TranslatedFields
 from parler.managers import TranslatableManager
+from cms.models import CMSPlugin
 from cms.models.fields import PlaceholderField
 from cms.utils.i18n import get_current_language
 from filer.fields.image import FilerImageField
@@ -265,3 +266,41 @@ class Post(TranslatableModel):
             previous_next = (previous, next)
             setattr(self, 'previous_next', previous_next)
         return previous_next
+
+
+# Plugin configuration models
+
+@python_2_unicode_compatible
+class PostList(CMSPlugin):
+    number_of_posts = models.IntegerField(default=bs.POSTS_PER_PAGE)
+
+    show_paginator = models.BooleanField(default=True)
+    orphans = models.IntegerField(default=0)
+
+    filter_by_author = models.ForeignKey(
+        USER_MODEL, blank=True, null=True,
+        related_name='filtered_by_author',
+        verbose_name=_('Filter by author'),
+        help_text=_('Filter by author or leave blank for all authors.'))
+    filter_by_category = TreeForeignKey(
+        Category, blank=True, null=True,
+        related_name='filtered_by_category',
+        verbose_name=_('Category'),
+        help_text=_('Filter by category or leave blank for all categories.'))
+    filter_by_tags = models.ManyToManyField(
+        Tag, blank=True, null=True,
+        related_name='filtered_by_tags',
+        verbose_name=_('Tags'),
+        help_text=_('Filter by tags (one or more) or '
+                    'leave blank for all tags.'))
+
+    template_name = models.CharField(
+        max_length=200, blank=True,
+        choices=bs.POST_LIST_TEMPLATES,
+        help_text=_('Select a template or leave empty for default one.'))
+
+    class Meta:
+        db_table = 'blogit_post_lists'
+
+    def __str__(self):
+        return 'Post List'

--- a/blogit/settings.py
+++ b/blogit/settings.py
@@ -37,3 +37,10 @@ POSTS_PER_PAGE = getattr(settings, 'BLOGIT_POSTS_PER_PAGE', 10)
 # Show detail url by date.
 POST_DETAIL_DATE_URL = getattr(
     settings, 'BLOGIT_POST_DETAIL_DATE_URL', False)
+
+
+# Plugins settings
+USE_BUILTIN_LIST_VIEW = getattr(
+    settings, 'BLOGIT_USE_BUILTIN_LIST_VIEW', True)
+POST_LIST_TEMPLATES = getattr(
+    settings, 'BLOGIT_POST_LIST_TEMPLATES', ())

--- a/blogit/templates/blogit/includes/posts.html
+++ b/blogit/templates/blogit/includes/posts.html
@@ -1,0 +1,20 @@
+  {% for object in object_list %}
+    <article>
+      <h2><a href="{{ object.get_absolute_url }}">{{ object.title }}</a></h2>
+      <p>{{ object.description }}</p>
+    </article>
+  {% endfor %}
+
+  {% if is_paginated %}
+    <ul class="pagination">
+      {% if page_obj.has_previous %}
+        <li><a href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
+      {% endif %}
+      {% for page_number in paginator.page_range %}
+        <li><a href="?page={{ page_number }}"{% if page_obj.number == page_number %} class="active"{% endif %}>{{ page_number }}</a></li>
+      {% endfor %}
+      {% if page_obj.has_next %}
+        <li><a href="?page={{ page_obj.next_page_number }}">Next</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}

--- a/blogit/templates/blogit/plugins/category_list.html
+++ b/blogit/templates/blogit/plugins/category_list.html
@@ -1,0 +1,3 @@
+{% for category in object_list %}
+    <a href="{{ category.get_absolute_url }}">{{ category.name }}</a><br>
+{% endfor %}

--- a/blogit/templates/blogit/plugins/post_list.html
+++ b/blogit/templates/blogit/plugins/post_list.html
@@ -1,0 +1,1 @@
+{% include "blogit/includes/posts.html" %}

--- a/blogit/templates/blogit/plugins/tag_list.html
+++ b/blogit/templates/blogit/plugins/tag_list.html
@@ -1,0 +1,3 @@
+{% for tag in object_list %}
+    <a href="{{ tag.get_absolute_url }}">{{ tag.name }}</a><br>
+{% endfor %}

--- a/blogit/templates/blogit/post_list.html
+++ b/blogit/templates/blogit/post_list.html
@@ -1,24 +1,5 @@
 {% extends "blogit/base.html" %}
 
 {% block body %}
-  {% for object in object_list %}
-    <article>
-      <h2><a href="{{ object.get_absolute_url }}">{{ object.title }}</a></h2>
-      <p>{{ object.description }}</p>
-    </article>
-  {% endfor %}
-
-  {% if is_paginated %}
-    <ul class="pagination">
-      {% if page_obj.has_previous %}
-        <li><a href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
-      {% endif %}
-      {% for page_number in paginator.page_range %}
-        <li><a href="?page={{ page_number }}"{% if page_obj.number == page_number %} class="active"{% endif %}>{{ page_number }}</a></li>
-      {% endfor %}
-      {% if page_obj.has_next %}
-        <li><a href="?page={{ page_obj.next_page_number }}">Next</a></li>
-      {% endif %}
-    </ul>
-  {% endif %}
+  {% include "blogit/includes/posts.html" %}
 {% endblock %}

--- a/blogit/urls.py
+++ b/blogit/urls.py
@@ -13,9 +13,11 @@ from blogit.views import (
 from blogit.feeds import PostRssFeed, PostAtomFeed
 
 
-pats = [
-    url(r'^$', PostListView.as_view(), name='blogit_post_list'),
+pats = []
+if bs.USE_BUILTIN_LIST_VIEW:
+    pats.append(url(r'^$', PostListView.as_view(), name='blogit_post_list'))
 
+pats.extend([
     url(r'^(?P<year>\d+)/(?P<month>[-\w\d]+)/(?P<day>\d+)/$',
         PostDayArchiveView.as_view(), name='blogit_post_archive_day'),
     url(r'^(?P<year>\d+)/(?P<month>[-\w\d]+)/$',
@@ -31,7 +33,7 @@ pats = [
     url(_(r'^tags/$'), TagListView.as_view(), name='blogit_tag_list'),
     url(_(r'^tags/(?P<slug>[-\w\d]+)/$'),
         TagDetailView.as_view(), name='blogit_tag_detail'),
-]
+])
 
 if bs.RSS_FEED:
     pats.extend([

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -52,3 +52,54 @@ url like this ``/<year>/<month>/<day>/<post_slug>/``, change this setting:
 .. code:: python
 
     BLOGIT_POST_DETAIL_DATE_URL = False
+
+=======
+Plugins
+=======
+
+With default configuration, the index page of the app (as configured by AppHook)
+displays a list of posts and can not be used with standard CMS plugins.  If you
+want, you can disable that view and create your own list page with ``Post List``
+plugin. To disable default list view, you need to do two things:
+
+1) In your ``settings.py``, define:
+
+.. code:: python
+
+    BLOGIT_USE_BUILTIN_LIST_VIEW = False
+
+2) Create your own ``blogit/post_list.html`` template and render your placeholders there.
+
+.. code:: django
+
+    {% placeholder "content" %}
+
+That setting is needed only if you want to build your own page for blog index
+with custom layout.  ``Post List`` plugin can be used no matter what
+``BLOGIT_USE_BUILTIN_LIST_VIEW`` setting is on any other page (not the page
+configured by AppHook).
+
+``Post List`` plugin can be configured to lists post filtered by author, tags
+or categories (those can be combined). It can also be configured to display only
+certain number of posts, and to display paginator or not (with orphans).
+
+Examples of use:
+
+* on ``/blog/`` page list all posts with pagination
+* on website homepage, lists 3 latest posts without pagination
+* on user's profile page (outside of ``blogit`` app),
+  list latest posts by that user
+
+For different cases, you can create different templates to be used with plugin.
+Define ``BLOGIT_POST_LIST_TEMPLATES`` like this:
+
+.. code:: python
+
+    BLOGIT_POST_LIST_TEMPLATES = (
+        ('blogit/plugins/post_list.html', 'Default'),
+        ('blogit/plugins/homepage.html', 'Latest posts on homepage'),
+        ...
+    )
+
+There are two more plugins available: ``Category List`` and ``Tag List``. Those
+can be used anywhere, even with default list view. They have no options.


### PR DESCRIPTION
I've added `cms_plugins.py` that implemetns three plugins:
- Post List
- Tag List
- Category List

The main idea is to be able to build (via CMS) `/blog/` page (or any other as defined by app hook) with standard CMS plugins that can be edited by content editors and do not require template modification. 

This change is fully backward compatible although to be able to use `Post List` plugin as a replacement for `PostListView`, a new seting is introduced. By default, everything works just as before and the only restriction is that `Post List` plugin can clash with `PostListView` if they are used on the same page (eg, `/blog/`.
